### PR TITLE
Expose current light client validators

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,9 +37,12 @@ function connect(GCI, opts = {}) {
     resolve({
       getState,
       send: sendTx,
-      state: Proxmise(async path => {
-        return await getState(path.join('.'))
-      })
+      state: Proxmise(path => {
+        return getState(path.join('.'))
+      }),
+      get validators () {
+        return lc._state.validators
+      }
     })
   })
 }


### PR DESCRIPTION
Maybe we should expose some other parts of the light client too? E.g. the rpc client or the most recent header/commit.